### PR TITLE
fix: Address multiple compilation errors

### DIFF
--- a/zeno/src/generator.rs
+++ b/zeno/src/generator.rs
@@ -97,7 +97,8 @@ fn generate_statement(statement: &Statement, writer: &mut String, indent_level: 
         }
         Statement::For { initializer, condition, increment, body_block } => {
             // Outer scope for the initializer if it's a LetDecl
-            let needs_outer_scope = matches!(initializer, Some(box Statement::LetDecl{..}));
+            // Corrected line:
+            let needs_outer_scope = matches!(initializer.as_deref(), Some(Statement::LetDecl{..}));
             if needs_outer_scope {
                 // This creates a slight oddity if the initializer isn't a let decl,
                 // but is required if `let` is used in the initializer part of a C-style for.


### PR DESCRIPTION
This commit resolves several compilation errors identified from build attempts:

1.  E0277, E0599 (Token trait bounds): Modified `Token::Float` to store `String` instead of `f64` and updated `Token` to derive `Eq` and `Hash`. This allows `Token` to be used as a key in `HashMap` (e.g., for operator precedences in the parser). Lexer and parser logic for float literals were adjusted accordingly.

2.  E0658 (Experimental box pattern): Replaced `matches!(..., Some(box Statement::LetDecl{..}))` with `matches!(....as_deref(), Some(Statement::LetDecl{..}))` in the generator to avoid unstable syntax.

3.  E0382 (Borrow of moved value): Ensured `Token` is cloned in the lexer's `tokenize` function before being pushed to a vector and then subsequently checked, resolving a borrow checker issue.

These changes should allow the Zeno compiler codebase to compile successfully.